### PR TITLE
Sketch of a solution to simplify troubleshooting

### DIFF
--- a/src/main/java/com/spotify/trickle/BindingDep.java
+++ b/src/main/java/com/spotify/trickle/BindingDep.java
@@ -99,5 +99,10 @@ class BindingDep<T> implements Dep<T> {
 
       return other.getName().equals(input);
     }
+
+    @Override
+    public String toString() {
+      return input.toString();
+    }
   }
 }

--- a/src/main/java/com/spotify/trickle/CallInfo.java
+++ b/src/main/java/com/spotify/trickle/CallInfo.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2013-2014 Spotify AB. All rights reserved.
+ *
+ * The contents of this file are licensed under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.trickle;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * TODO: document!
+ */
+public class CallInfo {
+  private final NodeInfo nodeInfo;
+  private final List<ParameterValue<?>> parameterValues;
+
+  public CallInfo(NodeInfo nodeInfo, List<ParameterValue<?>> parameterValues) {
+    this.nodeInfo = checkNotNull(nodeInfo, "nodeInfo");
+    this.parameterValues = ImmutableList.copyOf(parameterValues);
+  }
+
+  public NodeInfo getNodeInfo() {
+    return nodeInfo;
+  }
+
+  public List<ParameterValue<?>> getParameterValues() {
+    return parameterValues;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    CallInfo callInfo = (CallInfo) o;
+
+    if (!nodeInfo.equals(callInfo.nodeInfo)) {
+      return false;
+    }
+    if (!parameterValues.equals(callInfo.parameterValues)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = nodeInfo.hashCode();
+    result = 31 * result + parameterValues.hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("nodeInfo", nodeInfo)
+        .add("parameterValues", parameterValues)
+        .toString();
+  }
+}

--- a/src/main/java/com/spotify/trickle/Graph.java
+++ b/src/main/java/com/spotify/trickle/Graph.java
@@ -76,6 +76,19 @@ public abstract class Graph<T> implements Parameter<T>, NodeInfo {
    */
   abstract ListenableFuture<T> run(TraverseState state);
 
+  /**
+   * Turns debug information on or off depending on the value of the <code>debug</code> parameter.
+   * The default is on (true). When debug information is on, information about intermediate states -
+   * results and parameter values - for each node invocation in each graph invocation will be
+   * collected and reported in case of an exception that isn't caught by a
+   * {@link ConfigurableGraph#fallback(com.google.common.util.concurrent.AsyncFunction)}
+   *
+   * @param debug pass in <code>true</code> to turn on debug information, <code>false</code> to turn
+   *              off.
+   * @return a Graph instance with the specified debug setting
+   */
+  public abstract Graph<T> debug(boolean debug);
+
   // prevent construction from outside of package
   Graph() {}
 }

--- a/src/main/java/com/spotify/trickle/GraphBuilder.java
+++ b/src/main/java/com/spotify/trickle/GraphBuilder.java
@@ -43,37 +43,46 @@ class GraphBuilder<R> extends ConfigurableGraph<R> {
 
   private final Optional<AsyncFunction<Throwable, R>> fallback;
 
+  private final boolean debug;
+
   GraphBuilder(String name,
                TrickleNode<R> node,
                ImmutableList<Dep<?>> inputs,
                ImmutableList<Graph<?>> predecessors,
-               Optional<AsyncFunction<Throwable, R>> fallback) {
+               Optional<AsyncFunction<Throwable, R>> fallback,
+               boolean debug) {
     this.name = checkNotNull(name, "name");
     this.node = checkNotNull(node, "node");
     this.inputs = checkNotNull(inputs, "inputs");
     this.predecessors = checkNotNull(predecessors, "predecessors");
     this.fallback = checkNotNull(fallback, "fallback");
+    this.debug = debug;
   }
 
   GraphBuilder(Func<R> func) {
     this("unnamed", TrickleNode.create(func), ImmutableList.<Dep<?>>of(),
-         ImmutableList.<Graph<?>>of(), Optional.<AsyncFunction<Throwable, R>>absent());
+         ImmutableList.<Graph<?>>of(), Optional.<AsyncFunction<Throwable, R>>absent(), true);
   }
 
   private GraphBuilder<R> withName(String name) {
-    return new GraphBuilder<R>(name, node, inputs, predecessors, fallback);
+    return new GraphBuilder<R>(name, node, inputs, predecessors, fallback, debug);
   }
 
   private GraphBuilder<R> withInputs(ImmutableList<Dep<?>> newInputs) {
-    return new GraphBuilder<R>(name, node, with(inputs, newInputs), predecessors, fallback);
+    return new GraphBuilder<R>(name, node, with(inputs, newInputs), predecessors, fallback, debug);
   }
 
   private GraphBuilder<R> withPredecessors(ImmutableList<Graph<?>> newPredecessors) {
-    return new GraphBuilder<R>(name, node, inputs, with(predecessors, newPredecessors), fallback);
+    return new GraphBuilder<R>(name, node, inputs, with(predecessors, newPredecessors), fallback,
+                               debug);
   }
 
   private GraphBuilder<R> withFallback(AsyncFunction<Throwable, R> fallback) {
-    return new GraphBuilder<R>(name, node, inputs, predecessors, of(fallback));
+    return new GraphBuilder<R>(name, node, inputs, predecessors, of(fallback), debug);
+  }
+
+  private GraphBuilder<R> withDebug(boolean debug) {
+    return new GraphBuilder<R>(name, node, inputs, predecessors, fallback, debug);
   }
 
   static <E> ImmutableList<E> with(ImmutableList<E> list, List<E> elements) {
@@ -126,28 +135,33 @@ class GraphBuilder<R> extends ConfigurableGraph<R> {
   }
 
   @Override
+  public Graph<R> debug(boolean debug) {
+    return withDebug(debug);
+  }
+
+  @Override
   public <P> Graph<R> bind(Input<P> input, P value) {
-    return new PreparedGraph<R>(this).bind(input, value);
+    return new PreparedGraph<R>(this, debug).bind(input, value);
   }
 
   @Override
   public <P> Graph<R> bind(Input<P> input, ListenableFuture<P> inputFuture) {
-    return new PreparedGraph<R>(this).bind(input, inputFuture);
+    return new PreparedGraph<R>(this, debug).bind(input, inputFuture);
   }
 
   @Override
   public ListenableFuture<R> run() {
-    return new PreparedGraph<R>(this).run();
+    return new PreparedGraph<R>(this, debug).run();
   }
 
   @Override
   public ListenableFuture<R> run(Executor executor) {
-    return new PreparedGraph<R>(this).run(executor);
+    return new PreparedGraph<R>(this, debug).run(executor);
   }
 
   @Override
   ListenableFuture<R> run(TraverseState state) {
-    return new PreparedGraph<R>(this).run(state);
+    return new PreparedGraph<R>(this, debug).run(state);
   }
 
   TrickleNode<R> getNode() {

--- a/src/main/java/com/spotify/trickle/GraphExecutionException.java
+++ b/src/main/java/com/spotify/trickle/GraphExecutionException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2014 Spotify AB. All rights reserved.
+ *
+ * The contents of this file are licensed under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.trickle;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+/**
+ * TODO: document!
+ */
+public class GraphExecutionException extends RuntimeException {
+  private final List<CallInfo> calls;
+
+  public GraphExecutionException(@Nullable Throwable cause, List<CallInfo> calls) {
+    super(cause);
+    this.calls = ImmutableList.copyOf(calls);
+  }
+
+  public List<CallInfo> getCalls() {
+    return calls;
+  }
+}

--- a/src/main/java/com/spotify/trickle/ParameterValue.java
+++ b/src/main/java/com/spotify/trickle/ParameterValue.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2013-2014 Spotify AB. All rights reserved.
+ *
+ * The contents of this file are licensed under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.trickle;
+
+import com.google.common.base.Objects;
+
+import javax.annotation.Nullable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * TODO: document!
+ */
+public class ParameterValue<T> {
+  private final NodeInfo parameter;
+  private final T value;
+
+  public ParameterValue(NodeInfo parameter, @Nullable T value) {
+    this.parameter = checkNotNull(parameter, "parameter");
+    this.value = value;
+  }
+
+  public T getValue() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ParameterValue that = (ParameterValue) o;
+
+    if (!parameter.equals(that.parameter)) {
+      return false;
+    }
+    if (value != null ? !value.equals(that.value) : that.value != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = parameter.hashCode();
+    result = 31 * result + (value != null ? value.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("parameter", parameter)
+        .add("value", value)
+        .toString();
+  }
+}

--- a/src/test/java/com/spotify/trickle/TrickleTest.java
+++ b/src/test/java/com/spotify/trickle/TrickleTest.java
@@ -16,30 +16,43 @@
 
 package com.spotify.trickle;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import javax.annotation.Nullable;
+
+import static com.google.common.collect.Collections2.filter;
 import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.spotify.trickle.Fallbacks.always;
 import static com.spotify.trickle.Trickle.call;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Integration-level Trickle tests.
@@ -52,6 +65,9 @@ public class TrickleTest {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
+  private Input<String> debugInfoInput;
+  private Graph<Integer> debugInfoLength;
+  private Graph<String> debugInfoReport;
 
   @Before
   public void setUp() throws Exception {
@@ -64,6 +80,7 @@ public class TrickleTest {
       }
     };
     executorService = MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor());
+    debugInfoInput = Input.named("weirdName");
   }
 
   @After
@@ -434,8 +451,8 @@ public class TrickleTest {
     Graph<String> g1 = call(node1).with(input);
     Graph<String> g = call(node2).with(g1, input);
 
-    thrown.expect(ExecutionException.class);
-    thrown.expectCause(equalTo(expected));
+    thrown.expect(Exception.class);
+    thrown.expectCause(withParent(expected));
 
     g.bind(input, "hey").run().get();
   }
@@ -461,14 +478,14 @@ public class TrickleTest {
 
     Graph<String> g1 = call(node1).with(input).fallback(new AsyncFunction<Throwable, String>() {
       @Override
-      public ListenableFuture<String> apply(Throwable input) throws Exception {
+      public ListenableFuture<String> apply(@Nullable Throwable ignored) throws Exception {
         throw expected;
       }
     });
     Graph<String> g = call(node2).with(g1, input);
 
-    thrown.expect(ExecutionException.class);
-    thrown.expectCause(equalTo(expected));
+    thrown.expect(Exception.class);
+    thrown.expectCause(withParent(expected));
 
     g.bind(input, "hey").run().get();
   }
@@ -513,5 +530,162 @@ public class TrickleTest {
     inputFuture.set("hey there");
 
     assertThat(future.get(), equalTo(9));
+  }
+
+  @Test
+  public void shouldReportDebugInfoOnFailure() throws Exception {
+    RuntimeException expected = new RuntimeException("expected");
+    Graph<String> g = call(failingFunction(expected)).with(setupDebugInfoGraph()).named("failure")
+        .bind(debugInfoInput, "fail me").debug(true);
+
+    thrown.expect(Exception.class);
+    thrown.expectCause(CoreMatchers.<Throwable>instanceOf(GraphExecutionException.class));
+    thrown.expectCause(withParent(expected));
+
+    g.run().get();
+  }
+
+  @Test
+  public void shouldIncludePreviousNodesInDebugInfo() throws Exception {
+    RuntimeException expected = new RuntimeException("expected");
+    Graph<String> g = call(failingFunction(expected)).with(setupDebugInfoGraph()).named("failure")
+        .bind(debugInfoInput, "fail me").debug(true);
+
+    try {
+      g.run().get();
+    }
+    catch (ExecutionException e) {
+      GraphExecutionException graphExecutionException = (GraphExecutionException) e.getCause();
+
+      List<CallInfo> calls = graphExecutionException.getCalls();
+
+      for (CallInfo call : calls) {
+        System.out
+            .println("Called '" + call.getNodeInfo() + "' with: " + call.getParameterValues());
+      }
+
+      ParameterValue<String> inputParameterValue = new ParameterValue<String>(
+          new BindingDep<String>(debugInfoInput).getNodeInfo(), "fail me");
+      final ImmutableList<ParameterValue<?>> lengthParams =
+          ImmutableList.<ParameterValue<?>>of(inputParameterValue);
+      ImmutableList<ParameterValue<?>> reportParams =
+          ImmutableList.<ParameterValue<?>>of(inputParameterValue,
+                                              new ParameterValue<Integer>(debugInfoLength, 7));
+
+      assertThat(filter(calls, new CallInfoMatcher(debugInfoLength, lengthParams)).isEmpty(), is(false));
+      assertThat(filter(calls, new CallInfoMatcher(debugInfoReport, reportParams)).isEmpty(), is(false));
+    }
+  }
+
+  @Test
+  public void shouldNotIncludeDebugInfoTwice() throws Exception {
+    // if a node other than the last fails, only the first failure should be wrapped in an exception
+    fail("not implemented");
+  }
+
+  @Test
+  public void shouldNotReportDebugInfoIfOff() throws Exception {
+    RuntimeException expected = new RuntimeException("expected");
+    Graph<String> g = call(failingFunction(expected)).with(setupDebugInfoGraph()).named("failure")
+        .bind(debugInfoInput, "fail me").debug(false);
+
+    thrown.expect(Exception.class);
+    thrown.expectCause(not(CoreMatchers.<Throwable>instanceOf(GraphExecutionException.class)));
+    thrown.expectCause(withParent(expected));
+
+    g.run().get();
+  }
+
+  @Test
+  public void shouldSupportTurningOffDebugInfoBeforeBinding() throws Exception {
+    RuntimeException expected = new RuntimeException("expected");
+    Graph<String> g = call(failingFunction(expected)).with(setupDebugInfoGraph()).named("failure")
+        .debug(false)
+        .bind(debugInfoInput, "fail me");
+
+    thrown.expect(Exception.class);
+    thrown.expectCause(not(CoreMatchers.<Throwable>instanceOf(GraphExecutionException.class)));
+    thrown.expectCause(withParent(expected));
+
+    g.run().get();
+  }
+
+  @Test
+  public void shouldHaveDebugInfoOnByDefault() throws Exception {
+    RuntimeException expected = new RuntimeException("expected");
+    Graph<String> g = call(failingFunction(expected)).with(setupDebugInfoGraph()).named("failure")
+        .bind(debugInfoInput, "fail me");
+
+    thrown.expect(Exception.class);
+    thrown.expectCause(CoreMatchers.<Throwable>instanceOf(GraphExecutionException.class));
+    thrown.expectCause(withParent(expected));
+
+    g.run().get();
+  }
+
+  private Graph<String> setupDebugInfoGraph() {
+    Func1<String, Integer> func1 = new Func1<String, Integer>() {
+      @Override
+      public ListenableFuture<Integer> run(String arg) {
+        return immediateFuture(arg.length());
+      }
+    };
+    Func2<String, Integer, String> func2 = new Func2<String, Integer, String>() {
+      @Override
+      public ListenableFuture<String> run(String name, Integer length) {
+        return immediateFuture(String.format("Name %s is %d chars long", name, length));
+      }
+    };
+
+    debugInfoLength = call(func1).with(debugInfoInput).named("length calculation");
+    debugInfoReport = call(func2).with(debugInfoInput, debugInfoLength).named("report name and length");
+
+    return debugInfoReport;
+  }
+
+  private Func1<String, String> failingFunction(final Throwable expected) {
+    return new Func1<String, String>() {
+      @Override
+      public ListenableFuture<String> run(String arg) {
+        return immediateFailedFuture(expected);
+      }
+    };
+  }
+
+  private Matcher<? extends Throwable> withParent(final Throwable expected) {
+    return new TypeSafeMatcher<Throwable>() {
+      @Override
+      protected boolean matchesSafely(Throwable item) {
+        for (Throwable cause = item ; cause != null ; cause = cause.getCause()) {
+          if (cause.equals(expected)) {
+            return true;
+          }
+        }
+
+        return false;
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("with parent cause " + expected);
+      }
+    };
+  }
+
+  private class CallInfoMatcher implements Predicate<CallInfo> {
+
+    private final Graph<?> nodeInfo;
+    private final ImmutableList<ParameterValue<?>> parameters;
+
+    public CallInfoMatcher(Graph<?> nodeInfo, ImmutableList<ParameterValue<?>> parameters) {
+      this.nodeInfo = nodeInfo;
+      this.parameters = parameters;
+    }
+
+    @Override
+    public boolean apply(CallInfo input) {
+      return input.getNodeInfo().name().equals(nodeInfo.name()) &&
+          input.getParameterValues().equals(parameters);
+    }
   }
 }


### PR DESCRIPTION
Here's an incomplete and incorrect sketch for how to include more debug information when something goes wrong during graph execution. Not to be merged, just for discussion. The core idea is to track each graph invocation, and when something goes wrong, to report what happened before, including parameter values.

Things that I know are bad about the current implementation:
- I don't believe it's thread safe (but I haven't thought much about it so if I'm lucky it could be..)
- Not all tests pass (and I'm pretty sure there are others that should be written)
- I don't think that the 'debug' flag will be set correctly in all cases - in particular, I think that debug information will be tracked for 'predecessor sub-graphs', even if turned off at the root. In general, the debug flag probably lives at the wrong level; it should perhaps be set in the TraverseState directly, so as to ensure that a given execution of a graph uses the same debug setting when executing all nodes.
- It needs cleaning up in terms of javadoc, formatting, etc.

So, the main point is, does this seem like a reasonable way forward? How can it be improved?
