### PR TITLE
Add support for operating on `List`s of `Parameter`s.

### DIFF
--- a/src/main/java/com/spotify/trickle/GraphBuilder.java
+++ b/src/main/java/com/spotify/trickle/GraphBuilder.java
@@ -277,4 +277,17 @@ class GraphBuilder<R> extends ConfigurableGraph<R> {
       return super.with(arg1, arg2, arg3, arg4, arg5);
     }
   }
+
+  static final class ListGraphBuilder<A, R> extends GraphBuilder<R>
+      implements Trickle.NeedsParameterList<A, R> {
+
+    ListGraphBuilder(ListFunc<A, R> func) {
+      super(func);
+    }
+
+    @Override
+    public ConfigurableGraph<R> with(List<? extends Parameter<A>> args) {
+      return super.with(args.toArray(new Parameter[args.size()]));
+    }
+  }
 }

--- a/src/main/java/com/spotify/trickle/ListFunc.java
+++ b/src/main/java/com/spotify/trickle/ListFunc.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-2014 Spotify AB. All rights reserved.
+ *
+ * The contents of this file are licensed under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.trickle;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * Code that has as input a {@link List} of type A and returns a value of type R. Side-effects such
+ * as writing to a database are permitted, but authors are encouraged to keep implementations free
+ * of side-effects if at all possible.
+ */
+public interface ListFunc<A, R> extends Func<R> {
+
+  ListenableFuture<R> run(@Nonnull List<? extends A> arg);
+
+}

--- a/src/main/java/com/spotify/trickle/Trickle.java
+++ b/src/main/java/com/spotify/trickle/Trickle.java
@@ -16,6 +16,8 @@
 
 package com.spotify.trickle;
 
+import java.util.List;
+
 /**
  * Static methods for constructing Trickle graphs. See the documentation at
  * <a href="https://github.com/spotify/trickle/wiki">the Trickle wiki</a> for more information.
@@ -72,6 +74,14 @@ public final class Trickle {
     return new GraphBuilder.GraphBuilder5<A, B, C, D, E, R>(func);
   }
 
+  /**
+   * Initiates construction of a new sink node with five parameter dependencies, running the
+   * supplied function.
+   */
+  public static <A, R> NeedsParameterList<A, R> call(ListFunc<A, R> func) {
+    return new GraphBuilder.ListGraphBuilder<A, R>(func);
+  }
+
   public interface NeedsParameters1<A, R> {
     /**
      * Indicate where to find values for the parameters required to invoke the function in this
@@ -110,5 +120,9 @@ public final class Trickle {
      * node.
      */
     ConfigurableGraph<R> with(Parameter<A> arg1, Parameter<B> arg2, Parameter<C> arg3, Parameter<D> arg4, Parameter<E> arg5);
+  }
+
+  public interface NeedsParameterList<A, R> {
+      ConfigurableGraph<R> with(List<? extends Parameter<A>> args);
   }
 }

--- a/src/main/java/com/spotify/trickle/TrickleNode.java
+++ b/src/main/java/com/spotify/trickle/TrickleNode.java
@@ -50,6 +50,9 @@ abstract class TrickleNode<N> {
     if (func instanceof Func5) {
       return new TrickleNode5<Object, Object, Object, Object, Object, V>((Func5<Object, Object, Object, Object, Object, V>) func);
     }
+    if (func instanceof ListFunc) {
+        return new TrickleListNode<Object, V>((ListFunc<Object, V>) func);
+    }
 
     throw new IllegalArgumentException("unsupported func subclass: " + func.getClass());
   }
@@ -145,6 +148,21 @@ abstract class TrickleNode<N> {
       //noinspection unchecked
       return delegate.run((A) values.get(0), (B) values.get(1), (C) values.get(2), (D) values.get(3), (E) values.get(4));
       //CHECKSTYLE:ON
+    }
+  }
+
+  private static class TrickleListNode<A, N> extends TrickleNode<N> {
+    private final ListFunc<A, N> delegate;
+
+    public TrickleListNode(ListFunc<A, N> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public ListenableFuture<N> run(List<Object> values) {
+      // this cast is safe, as guaranteed by the API for creating nodes
+      //noinspection unchecked
+      return delegate.run((List<? extends A>)values);
     }
   }
 }


### PR DESCRIPTION
This patch adds a `ListFunc<A, R>` type for tasks that require a `List` of arguments of type `A`, and the ability to `call()` it with a `List<? extends Parameter<A>>`.  See the added test case for an example use.

Since the library already is working with `List`s behind the scenes, it hardly took any doing to add this capability to the front-end.  The intended use case is when you have a fan-in join point that depends on a runtime-determined number of inputs, all of the same type.