### PR TITLE
Add Maven Shade plugin configuration to create a shaded artifact JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,29 @@
           </targetTests>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.1</version>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>com.google.common</pattern>
+              <shadedPattern>com.spotify.trickle.shaded.guava</shadedPattern>
+            </relocation>
+          </relocations>
+          <shadedArtifactAttached>true</shadedArtifactAttached>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Add Maven Shade plugin configuration to create a shaded artifact JAR that bundles a relocated Guava.  This allows Trickle to be bundled with projects that require a different, incompatible Guava version.