### PR TITLE
Upgrade to Guava 21.0 (Java 8+ only)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,10 @@
   <description>A small library for composing asynchronous Java code.</description>
 
   <properties>
-    <guava.version>17.0</guava.version>
+    <guava.version>21.0</guava.version>
 
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/src/main/java/com/spotify/trickle/Graph.java
+++ b/src/main/java/com/spotify/trickle/Graph.java
@@ -50,7 +50,7 @@ public abstract class Graph<T> implements Parameter<T>, NodeInfo {
   /**
    * Run the graph, executing all node methods on the thread that completes the underlying future.
    * This is equivalent to calling {@link #run(java.util.concurrent.Executor)} with {@link
-   * com.google.common.util.concurrent.MoreExecutors#sameThreadExecutor()}.
+   * com.google.common.util.concurrent.MoreExecutors#directExecutor()}.
    *
    * @return a future for the value returned by the graph execution
    * @throws IllegalArgumentException if not all {@link Input}s used in node invocations are bound

--- a/src/main/java/com/spotify/trickle/NodeExecutionFallback.java
+++ b/src/main/java/com/spotify/trickle/NodeExecutionFallback.java
@@ -16,7 +16,7 @@
 
 package com.spotify.trickle;
 
-import com.google.common.util.concurrent.FutureFallback;
+import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -26,7 +26,7 @@ import static com.spotify.trickle.GraphExceptionWrapper.wrapException;
 /**
  * Fallback that handles errors when executing a graph node.
  */
-class NodeExecutionFallback<R> implements FutureFallback<R> {
+class NodeExecutionFallback<R> implements AsyncFunction<Throwable, R> {
 
   private final TraverseState.FutureCallInformation currentCall;
   private final TraverseState state;
@@ -41,7 +41,7 @@ class NodeExecutionFallback<R> implements FutureFallback<R> {
   }
 
   @Override
-  public ListenableFuture<R> create(Throwable t) {
+  public ListenableFuture<R> apply(Throwable t) {
     if (graph.getFallback().isPresent()) {
       try {
         return graph.getFallback().get().apply(t);

--- a/src/test/java/com/spotify/trickle/GraphExceptionWrapperTest.java
+++ b/src/test/java/com/spotify/trickle/GraphExceptionWrapperTest.java
@@ -66,7 +66,7 @@ public class GraphExceptionWrapperTest {
     t = new RuntimeException("the original problem");
 
     Map<Input<?>, Object> emptyMap = Collections.emptyMap();
-    traverseState = new TraverseState(emptyMap, MoreExecutors.sameThreadExecutor(), true);
+    traverseState = new TraverseState(emptyMap, MoreExecutors.directExecutor(), true);
 
     List<? extends NodeInfo> currentNodeParameters = ImmutableList.of(
         new FakeNodeInfo("arg1", Collections .<NodeInfo>emptyList()),

--- a/src/test/java/com/spotify/trickle/NodeExecutionFallbackTest.java
+++ b/src/test/java/com/spotify/trickle/NodeExecutionFallbackTest.java
@@ -60,7 +60,7 @@ public class NodeExecutionFallbackTest {
         .thenReturn(Optional.<AsyncFunction<Throwable, String>>absent());
 
     Map<Input<?>, Object> emptyMap = Collections.emptyMap();
-    traverseState = new TraverseState(emptyMap, MoreExecutors.sameThreadExecutor(), true);
+    traverseState = new TraverseState(emptyMap, MoreExecutors.directExecutor(), true);
 
     List<? extends NodeInfo> currentNodeParameters = ImmutableList.of();
 
@@ -77,7 +77,7 @@ public class NodeExecutionFallbackTest {
   public void shouldNotWrapGraphExecutionException() throws Exception {
     Throwable expected = new GraphExecutionException(null, currentCallInfo, NO_CALLS);
 
-    ListenableFuture<String> future = fallback.create(expected);
+    ListenableFuture<String> future = fallback.apply(expected);
 
     try {
       future.get();
@@ -91,7 +91,7 @@ public class NodeExecutionFallbackTest {
   public void shouldWrapGeneralException() throws Exception {
     Throwable expected = new RuntimeException("expected");
 
-    ListenableFuture<String> future = fallback.create(expected);
+    ListenableFuture<String> future = fallback.apply(expected);
 
     try {
       future.get();
@@ -115,7 +115,7 @@ public class NodeExecutionFallbackTest {
 
     Throwable expected = new GraphExecutionException(null, currentCallInfo, NO_CALLS);
 
-    ListenableFuture<String> future = fallback.create(expected);
+    ListenableFuture<String> future = fallback.apply(expected);
 
     assertThat(future.get(), equalTo("all is well, nothing to see here"));
   }

--- a/src/test/java/com/spotify/trickle/PackageSanityTest.java
+++ b/src/test/java/com/spotify/trickle/PackageSanityTest.java
@@ -80,7 +80,7 @@ public class PackageSanityTest extends AbstractPackageSanityTests {
 
     setDefault(Graph.class, graphBuilder);
     setDefault(GraphBuilder.class, graphBuilder);
-    setDefault(TraverseState.class, TraverseState.empty(MoreExecutors.sameThreadExecutor(), false));
+    setDefault(TraverseState.class, TraverseState.empty(MoreExecutors.directExecutor(), false));
     setDefault(TraverseState.FutureCallInformation.class, NO_INFO);
     setDefault(CallInfo.class,
                new CallInfo(graphBuilder, Collections.<ParameterValue<?>>emptyList()));

--- a/src/test/java/com/spotify/trickle/TrickleErrorHandlingTest.java
+++ b/src/test/java/com/spotify/trickle/TrickleErrorHandlingTest.java
@@ -17,34 +17,29 @@
 package com.spotify.trickle;
 
 import com.google.common.base.Function;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
-
-import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-
-import javax.annotation.Nullable;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.spotify.trickle.Trickle.call;
 import static com.spotify.trickle.Util.hasAncestor;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -346,7 +341,7 @@ public class TrickleErrorHandlingTest {
 
     @Override
     public String toString() {
-      return Objects.toStringHelper(this)
+      return MoreObjects.toStringHelper(this)
           .add("nodeName", nodeName)
           .add("parameterNames", parameterNames)
           .add("parameterValues", parameterValues)


### PR DESCRIPTION
I had a quick shot at upgrading the library to Guava 21.0 (Java 8+ only) to see how much work it would be, and it seems like it's very little effort.  I make this pull request for your reference, since this would mean dropping support for Java 7 and earlier, I leave it to your discretion what's the right time for you guys to make this move.

(Some automatic IDE import rewrites snuck into the pull request.)